### PR TITLE
Pass along all parameters that mongojs supports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ exports.db = () => _plugin.db;
 
 exports.register = (server, options, next) => {
   try {
-    const db = mongojs(options.url);
+    const db = mongojs(options.url, options.collections, options.options);
     // verify connection
     db.runCommand({serverStatus: 1});
     _plugin.db = db;


### PR DESCRIPTION
It looks like mongojs is ignoring options passed to connection string, see:
http://mongodb.github.io/node-mongodb-native/2.2/reference/connecting/connection-settings/

This patch passes along all parameters supported by mongojs.

**PLEASE** consider publishing a `1.0.2` version! As you may know ;) we are using `1.0.1` in production and more recent version of hapi-mongojs have different peer dependencies on hapi library!

Thanks Nik ;)